### PR TITLE
Add base64ToArray cast method

### DIFF
--- a/src/Exceptions/InvalidBase64StringException.php
+++ b/src/Exceptions/InvalidBase64StringException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DF\SmartCast\Exceptions;
+
+use Throwable;
+
+class InvalidBase64StringException extends InvalidArgumentException
+{
+    public function __construct(
+        mixed $value,
+        ?string $message = null,
+        int $code = 0,
+        ?Throwable $previous = null,
+    ) {
+        $message = $message ?? "Value '{$this->prepareValue($value)}' is not a valid base64 string";
+
+        parent::__construct($value, $message, $code, $previous);
+    }
+}

--- a/src/Exceptions/InvalidJsonStringException.php
+++ b/src/Exceptions/InvalidJsonStringException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DF\SmartCast\Exceptions;
+
+use Throwable;
+
+class InvalidJsonStringException extends InvalidArgumentException
+{
+    public function __construct(
+        mixed $value,
+        ?string $message = null,
+        int $code = 0,
+        ?Throwable $previous = null,
+    ) {
+        $message = $message ?? "Value '{$this->prepareValue($value)}' is not a valid JSON string";
+
+        parent::__construct($value, $message, $code, $previous);
+    }
+}

--- a/src/SmartCast.php
+++ b/src/SmartCast.php
@@ -8,7 +8,9 @@ use BackedEnum;
 use DF\SmartCast\Exceptions\FloatOverflowException;
 use DF\SmartCast\Exceptions\IntegerOverflowException;
 use DF\SmartCast\Exceptions\InvalidArgumentException;
+use DF\SmartCast\Exceptions\InvalidBase64StringException;
 use DF\SmartCast\Exceptions\InvalidBooleanStringException;
+use DF\SmartCast\Exceptions\InvalidJsonStringException;
 use DF\SmartCast\Exceptions\InvalidNumberSignException;
 use DF\SmartCast\Exceptions\InvalidTypeException;
 use DF\SmartCast\Exceptions\NotNumericException;
@@ -233,6 +235,48 @@ class SmartCast
         }
 
         throw new InvalidTypeException($value);
+    }
+
+    /**
+     * Decodes a base64-encoded string into a PHP array
+     *
+     * The input must be a base64-encoded JSON object or array.
+     * Pipeline: base64 decode → JSON decode → PHP array.
+     *
+     * @param  string|null  $value      The base64-encoded string to decode
+     * @param  bool         $acceptNull If false, throws exception when value is null
+     * @return array|null   Decoded associative array or null if accepted
+     *
+     * @throws InvalidTypeException         When value is null and null is not accepted
+     * @throws InvalidBase64StringException When value is not valid base64
+     * @throws InvalidJsonStringException   When decoded value is not valid JSON
+     * @throws InvalidTypeException         When decoded JSON is not an array or object
+     */
+    public static function base64ToArray(
+        string|null $value,
+        bool $acceptNull = false,
+    ): ?array {
+        if (static::checkNullable($value, $acceptNull) && $value === null) {
+            return null;
+        }
+
+        $decoded = base64_decode($value, strict: true);
+
+        if ($decoded === false) {
+            throw new InvalidBase64StringException($value);
+        }
+
+        $result = json_decode($decoded, associative: true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new InvalidJsonStringException($value);
+        }
+
+        if (!is_array($result)) {
+            throw new InvalidTypeException($value);
+        }
+
+        return $result;
     }
 
     private static function checkIsNumeric(string|int|float $value): void

--- a/src/SmartCast.php
+++ b/src/SmartCast.php
@@ -243,17 +243,17 @@ class SmartCast
      * The input must be a base64-encoded JSON object or array.
      * Pipeline: base64 decode → JSON decode → PHP array.
      *
-     * @param  string|null  $value      The base64-encoded string to decode
-     * @param  bool         $acceptNull If false, throws exception when value is null
-     * @return array|null   Decoded associative array or null if accepted
+     * @param  string|null  $value  The base64-encoded string to decode
+     * @param  bool  $acceptNull  If false, throws exception when value is null
+     * @return array|null Decoded associative array or null if accepted
      *
-     * @throws InvalidTypeException         When value is null and null is not accepted
+     * @throws InvalidTypeException When value is null and null is not accepted
      * @throws InvalidBase64StringException When value is not valid base64
-     * @throws InvalidJsonStringException   When decoded value is not valid JSON
-     * @throws InvalidTypeException         When decoded JSON is not an array or object
+     * @throws InvalidJsonStringException When decoded value is not valid JSON
+     * @throws InvalidTypeException When decoded JSON is not an array or object
      */
     public static function base64ToArray(
-        string|null $value,
+        ?string $value,
         bool $acceptNull = false,
     ): ?array {
         if (static::checkNullable($value, $acceptNull) && $value === null) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -89,12 +89,12 @@ if (!function_exists('base64ToArray')) {
     /**
      * Decodes a base64-encoded string into a PHP array
      *
-     * @param  string|null  $value      The base64-encoded string to decode
-     * @param  bool         $acceptNull If false, throws exception when value is null
-     * @return array|null   Decoded associative array or null if accepted
+     * @param  string|null  $value  The base64-encoded string to decode
+     * @param  bool  $acceptNull  If false, throws exception when value is null
+     * @return array|null Decoded associative array or null if accepted
      */
     function base64ToArray(
-        string|null $value,
+        ?string $value,
         bool $acceptNull = false,
     ): ?array {
         return SmartCast::base64ToArray($value, $acceptNull);

--- a/src/functions.php
+++ b/src/functions.php
@@ -85,6 +85,22 @@ if (!function_exists('stringToArray')) {
     }
 }
 
+if (!function_exists('base64ToArray')) {
+    /**
+     * Decodes a base64-encoded string into a PHP array
+     *
+     * @param  string|null  $value      The base64-encoded string to decode
+     * @param  bool         $acceptNull If false, throws exception when value is null
+     * @return array|null   Decoded associative array or null if accepted
+     */
+    function base64ToArray(
+        string|null $value,
+        bool $acceptNull = false,
+    ): ?array {
+        return SmartCast::base64ToArray($value, $acceptNull);
+    }
+}
+
 if (!function_exists('ensureAllowedString')) {
     /**
      * Ensures that a given value is a valid string and belongs to the specified set of allowed values.

--- a/src/legacy_aliases.php
+++ b/src/legacy_aliases.php
@@ -14,3 +14,5 @@ class_alias('DF\\SmartCast\\Exceptions\\InvalidTypeException', 'DF\\Exceptions\\
 class_alias('DF\\SmartCast\\Exceptions\\OverflowException', 'DF\\Exceptions\\OverflowException');
 class_alias('DF\\SmartCast\\Exceptions\\ZeroValueException', 'DF\\Exceptions\\ZeroValueException');
 class_alias('DF\\SmartCast\\Exceptions\\InvalidBooleanStringException', 'DF\\Exceptions\\InvalidBooleanStringException');
+class_alias('DF\\SmartCast\\Exceptions\\InvalidBase64StringException', 'DF\\Exceptions\\InvalidBase64StringException');
+class_alias('DF\\SmartCast\\Exceptions\\InvalidJsonStringException', 'DF\\Exceptions\\InvalidJsonStringException');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+use Tests\TestCase;
 
 /*
 |--------------------------------------------------------------------------
@@ -13,7 +14,7 @@ declare(strict_types=1);
 |
 */
 
-pest()->extend(Tests\TestCase::class)->in('Unit');
+pest()->extend(TestCase::class)->in('Unit');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/Base64ToArrayTest.php
+++ b/tests/Unit/Base64ToArrayTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use DF\SmartCast\Exceptions\InvalidBase64StringException;
+use DF\SmartCast\Exceptions\InvalidJsonStringException;
+use DF\SmartCast\Exceptions\InvalidTypeException;
+use DF\SmartCast\SmartCast;
+
+it('decodes base64-encoded JSON array', function () {
+    // [1,2,3]
+    expect(SmartCast::base64ToArray('WzEsMiwzXQ=='))->toBe([1, 2, 3]);
+});
+
+it('decodes base64-encoded JSON object to associative array', function () {
+    // {"foo":"bar","baz":42}
+    expect(SmartCast::base64ToArray('eyJmb28iOiJiYXIiLCJiYXoiOjQyfQ=='))->toBe(['foo' => 'bar', 'baz' => 42]);
+});
+
+it('decodes base64-encoded empty JSON array', function () {
+    // []
+    expect(SmartCast::base64ToArray('W10='))->toBe([]);
+});
+
+it('decodes base64-encoded empty JSON object', function () {
+    // {}
+    expect(SmartCast::base64ToArray('e30='))->toBe([]);
+});
+
+it('decodes base64-encoded nested JSON structure', function () {
+    // {"a":{"b":[1,2]}}
+    expect(SmartCast::base64ToArray('eyJhIjp7ImIiOlsxLDJdfX0='))->toBe(['a' => ['b' => [1, 2]]]);
+});
+
+it('decodes base64-encoded JSON array with mixed types', function () {
+    // [true,false,null]
+    expect(SmartCast::base64ToArray('W3RydWUsZmFsc2UsbnVsbF0='))->toBe([true, false, null]);
+});
+
+it('returns null when value is null and acceptNull is true', function () {
+    expect(SmartCast::base64ToArray(null, acceptNull: true))->toBeNull();
+});
+
+it('throws InvalidTypeException when value is null and acceptNull is false', function () {
+    SmartCast::base64ToArray(null);
+})->throws(InvalidTypeException::class);
+
+it('throws InvalidBase64StringException for string with invalid base64 characters', function () {
+    SmartCast::base64ToArray('not-valid-base64!!!');
+})->throws(InvalidBase64StringException::class);
+
+it('throws InvalidBase64StringException for string with wrong padding', function () {
+    SmartCast::base64ToArray('abc!');
+})->throws(InvalidBase64StringException::class);
+
+it('throws InvalidJsonStringException when decoded value is not valid JSON', function () {
+    // not json at all
+    SmartCast::base64ToArray('bm90IGpzb24gYXQgYWxs');
+})->throws(InvalidJsonStringException::class);
+
+it('throws InvalidJsonStringException when decoded value is truncated JSON', function () {
+    // [1,2,3  (truncated)
+    SmartCast::base64ToArray('WzEsMiwz');
+})->throws(InvalidJsonStringException::class);
+
+it('throws InvalidTypeException when decoded JSON is a string scalar', function () {
+    // "hello"
+    SmartCast::base64ToArray('ImhlbGxvIg==');
+})->throws(InvalidTypeException::class);
+
+it('throws InvalidTypeException when decoded JSON is a number', function () {
+    // 42
+    SmartCast::base64ToArray('NDI=');
+})->throws(InvalidTypeException::class);
+
+it('throws InvalidTypeException when decoded JSON is a boolean', function () {
+    // true
+    SmartCast::base64ToArray('dHJ1ZQ==');
+})->throws(InvalidTypeException::class);
+
+it('throws InvalidTypeException when decoded JSON is null literal', function () {
+    // null
+    SmartCast::base64ToArray('bnVsbA==');
+})->throws(InvalidTypeException::class);
+
+it('successfully decodes various base64-encoded JSON values', function (string $input, array $expected) {
+    expect(SmartCast::base64ToArray($input))->toBe($expected);
+})->with([
+    // [1,2,3]
+    ['WzEsMiwzXQ==', [1, 2, 3]],
+    // {"foo":"bar"}
+    ['eyJmb28iOiJiYXIifQ==', ['foo' => 'bar']],
+    // []
+    ['W10=', []],
+    // {}
+    ['e30=', []],
+    // [true,false,null]
+    ['W3RydWUsZmFsc2UsbnVsbF0=', [true, false, null]],
+]);


### PR DESCRIPTION
## Summary

- Adds `SmartCast::base64ToArray()` method that decodes a base64-encoded string into an associative PHP array (pipeline: base64 → JSON → array)
- Adds two new exceptions: `InvalidBase64StringException` and `InvalidJsonStringException`
- Adds global function wrapper `base64ToArray()` and legacy aliases
